### PR TITLE
Fix version file URL property

### DIFF
--- a/ExplorationPlus.version
+++ b/ExplorationPlus.version
@@ -1,6 +1,6 @@
 {
     "NAME"     : "Contract Pack: Exploration Plus",
-    "URL"      : "https://github.com/severedsolo/ExplorationPlus/blob/master/ExporationPlus.version",
+    "URL"      : "https://github.com/severedsolo/ExplorationPlus/raw/master/ExplorationPlus.version",
     "DOWNLOAD" : "https://github.com/severedsolo/ExplorationPlus/releases",
     "GITHUB" :
     {


### PR DESCRIPTION
The current link is a 404 (an 'l' is missing).
Now it's fixed.